### PR TITLE
chore: improves performance of middleware creation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ composer require jcchavezs/zipkin-instrumentation-guzzle
 
 ## Usage
 
-`ZipkinGuzzle\Middleware` is an [Guzzle middleware](http://docs.guzzlephp.org/en/stable/handlers-and-middleware.html) that can be 
-used along with `GuzzleHttp\Client` in order to create a span and propagate the context.
+`ZipkinGuzzle\Middleware` is an [Guzzle middleware](http://docs.guzzlephp.org/en/stable/handlers-and-middleware.html) that can be used along with `GuzzleHttp\Client` in order to create a span and propagate the context.
 
 ### Default handler
 
@@ -26,13 +25,13 @@ use ZipkinGuzzle\Middleware;
 
 $tracing = TracingBuilder::create()->build();
 
-// Default tags for all spans being created.
+// Default tags for all spans being created. They are not mandatory.
 $tags = [
    'instance' => $_SERVER['SERVER_NAME']
 ];
 
 $client = new Client([
-    'handler' => Middleware\handlerStack(Tracing $tracing, $tags),
+    'handler' => Middleware\handlerStack($tracing, $tags),
 ]);
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Zipkin instrumentation for Guzzle HTTP Client",
     "type": "library",
     "require": {
-        "openzipkin/zipkin": "^1.2.4",
+        "openzipkin/zipkin": "^1.3.6",
         "guzzlehttp/guzzle": "~6.2"
     },
     "require-dev": {

--- a/src/ZipkinGuzzle/RequestHeaders.php
+++ b/src/ZipkinGuzzle/RequestHeaders.php
@@ -24,7 +24,7 @@ final class RequestHeaders implements Setter
         }
         
         if ($carrier instanceof RequestInterface) {
-            $carrier = $carrier->withAddedHeader($key, $value);
+            $carrier = $carrier->withHeader($key, $value);
             return;
         }
 

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -54,7 +54,7 @@ final class MiddlewareTest extends PHPUnit_Framework_TestCase
 
         if ($expectedResponse instanceof RequestException
             || ($expectedResponse instanceof Response && $expectedResponse->getStatusCode() > 399)) {
-            $this->expectException(RequestException::Class);
+            $this->expectException(RequestException::class);
         }
 
         $actualResponse = $client->send($request);

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -18,6 +18,7 @@ use Zipkin\Reporters\InMemory as InMemoryReporter;
 final class MiddlewareTest extends PHPUnit_Framework_TestCase
 {
     const METHOD = 'POST';
+    const METHOD_LOWERCASE = 'post';
     const URI = 'http://domain.com/test?key=value';
     const HEADER_KEY = 'test_key';
     const HEADER_VALUE = 'test_value';
@@ -110,7 +111,7 @@ final class MiddlewareTest extends PHPUnit_Framework_TestCase
         return [
             [
                 [
-                    'name' => self::METHOD,
+                    'name' => 'http/' . self::METHOD_LOWERCASE,
                     'debug' => false,
                     'localEndpoint' => [
                         'serviceName' => 'cli',
@@ -120,14 +121,14 @@ final class MiddlewareTest extends PHPUnit_Framework_TestCase
                         'http.method' => self::METHOD,
                         'http.path' => '/test',
                         self::TAG_KEY => self::TAG_VALUE,
-                        'http.status_code' => 200,
+                        'http.status_code' => '200',
                     ],
                 ],
                 new Response(200)
             ],
             [
                 [
-                    'name' => self::METHOD,
+                    'name' => 'http/' . self::METHOD_LOWERCASE,
                     'debug' => false,
                     'localEndpoint' => [
                         'serviceName' => 'cli',
@@ -137,14 +138,14 @@ final class MiddlewareTest extends PHPUnit_Framework_TestCase
                         'http.method' => self::METHOD,
                         'http.path' => '/test',
                         self::TAG_KEY => self::TAG_VALUE,
-                        'http.status_code' => 300,
+                        'http.status_code' => '300',
                     ],
                 ],
                 new Response(300)
             ],
             [
                 [
-                    'name' => self::METHOD,
+                    'name' => 'http/' . self::METHOD_LOWERCASE,
                     'debug' => false,
                     'localEndpoint' => [
                         'serviceName' => 'cli',
@@ -154,15 +155,15 @@ final class MiddlewareTest extends PHPUnit_Framework_TestCase
                         'http.method' => self::METHOD,
                         'http.path' => '/test',
                         self::TAG_KEY => self::TAG_VALUE,
-                        'http.status_code' => 300,
-                        'error' => true,
+                        'http.status_code' => '300',
+                        'error' => 'true',
                     ],
                 ],
                 new Response(400)
             ],
             [
                 [
-                    'name' => self::METHOD,
+                    'name' => 'http/' . self::METHOD_LOWERCASE,
                     'debug' => false,
                     'localEndpoint' => [
                         'serviceName' => 'cli',
@@ -172,15 +173,15 @@ final class MiddlewareTest extends PHPUnit_Framework_TestCase
                         'http.method' => self::METHOD,
                         'http.path' => '/test',
                         self::TAG_KEY => self::TAG_VALUE,
-                        'http.status_code' => 400,
-                        'error' => true,
+                        'http.status_code' => '400',
+                        'error' => 'true',
                     ],
                 ],
                 new RequestException('Error 400', $this->getRequest(), new Response(400))
             ],
             [
                 [
-                    'name' => self::METHOD,
+                    'name' => 'http/' . self::METHOD_LOWERCASE,
                     'debug' => false,
                     'localEndpoint' => [
                         'serviceName' => 'cli',
@@ -189,9 +190,9 @@ final class MiddlewareTest extends PHPUnit_Framework_TestCase
                     'tags' => [
                         'http.method' => self::METHOD,
                         'http.path' => '/test',
-                        'http.status_code' => 500,
+                        'http.status_code' => '500',
                         self::TAG_KEY => self::TAG_VALUE,
-                        'error' => true,
+                        'error' => 'true',
                     ],
                 ],
                 new RequestException('Error 500', $this->getRequest(), new Response(500))


### PR DESCRIPTION
This PR improves the performance of the middleware by creating the injector on beforehand instead of every time a request comes in. This is probably not meaningful for SAPI models but it is for event loop ones.

It also improves the tagging and span naming.

Ping @drolando