### PR TITLE
chore: drops compatibility with PHP 5.6 and 7.0 and Zipkin 1.x.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,17 @@
 language: php
 
 php:
-  - "5.6"
-  - "7.0"
   - "7.1"
   - "7.2"
   - "7.3"
+  - "7.4"
 
 env:
-  - ZIPKIN_PHP_VERSION=^1.3.6
-  - ZIPKIN_PHP_VERSION=^2.0
-
-jobs:
-  exclude:
-    - php: "5.6"
-      env: ZIPKIN_PHP_VERSION=^2.0
-    - php: "7.0"
-      env: ZIPKIN_PHP_VERSION=^2.0
+  - GUZZLE_VERSION=~6.2
+  - GUZZLE_VERSION=^7.0
 
 install:
-  - composer require openzipkin/zipkin:"$ZIPKIN_PHP_VERSION"
+  - composer require guzzlehttp/guzzle:"$GUZZLE_VERSION"
   - composer install
 
 script:

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Zipkin instrumentation for Guzzle HTTP Client",
     "type": "library",
     "require": {
-        "openzipkin/zipkin": "^1.3.6|^2.0",
+        "openzipkin/zipkin": "^2.0",
         "guzzlehttp/guzzle": "~6.2 || ^7.0"
     },
     "require-dev": {


### PR DESCRIPTION
This PR drops compatibility with PHP 5.6 and 7.0 to be consistent with Zipkin PHP ecosystem.

Ping @Dipenduroy 