### PR TITLE
Resolves issue #16

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.0@dev",
-        "phpunit/phpunit": "^7.0"
+        "phpunit/phpunit": "^7.5.20 || ^9.0"
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
# Changed log

- According to the [composer.json](https://github.com/openzipkin/zipkin-php/blob/master/composer.json#L32) file, it should require `phpunit/phpunit` to be `^7.5.20` version at least.
- Closes #16.